### PR TITLE
Expose FSVideoRenderView.h

### DIFF
--- a/ijkmedia/wrapper/apple/FSPlayer.h
+++ b/ijkmedia/wrapper/apple/FSPlayer.h
@@ -25,6 +25,7 @@
 #import <FSPlayer/FSMediaPlayback.h>
 #import <FSPlayer/FSMonitor.h>
 #import <FSPlayer/FSOptions.h>
+#import <FSPlayer/FSVideoRenderView.h>
 #import <FSPlayer/FSVideoRenderingProtocol.h>
 #import <FSPlayer/FSAudioRenderingProtocol.h>
 


### PR DESCRIPTION
I need to be able to render the same video to multiple UIViews at the same time. There is a sample for exactly this use case, however when importing FSPlayer as a library FSMetalView is not publicly exposed.

Given that all I need is to be able to create an instance of `UIView<FSVideoRenderingProtocol>`, I figured that it would be better to add `FSVideoRenderView.h` to the umbrella header so that there is the option to create instances of either the GL view or Metal view.