### PR TITLE
通知FSPlayerIsPreparedToPlayNotification之前去更新playbackSchedule

### DIFF
--- a/ijkmedia/wrapper/apple/FSPlayer.m
+++ b/ijkmedia/wrapper/apple/FSPlayer.m
@@ -1555,6 +1555,8 @@ inline static void fillMetaInternal(NSMutableDictionary *meta, IjkMediaMeta *raw
             
             _isPreparedToPlay = YES;
             
+            [self updateAndNotifyPlaybackScheduleWithState:MP_STATE_PREPARED];
+            
             [[NSNotificationCenter defaultCenter] postNotificationName:FSPlayerIsPreparedToPlayNotification object:self];
             _loadState = FSPlayerLoadStatePlayable | FSPlayerLoadStatePlaythroughOK;
 


### PR DESCRIPTION
通知FSPlayerIsPreparedToPlayNotification之前去更新playbackSchedule，避免业务在FSPlayerIsPreparedToPlayNotification通知里获取不到正确的状态