### PR TITLE
FSVideoRenderingProtocol，displayDelegate属性需要设置@required

### DIFF
--- a/ijkmedia/ijksdl/mac/FSSDLGLView.m
+++ b/ijkmedia/ijksdl/mac/FSSDLGLView.m
@@ -127,6 +127,7 @@ static void unlock_gl(NSOpenGLContext *ctx)
     int    _rendererGravity;
 }
 
+@synthesize displayDelegate = _displayDelegate;
 @synthesize scalingMode = _scalingMode;
 // rotate preference
 @synthesize rotatePreference = _rotatePreference;
@@ -136,7 +137,6 @@ static void unlock_gl(NSOpenGLContext *ctx)
 @synthesize darPreference = _darPreference;
 @synthesize preventDisplay;
 @synthesize showHdrAnimation = _showHdrAnimation;
-@synthesize displayDelegate = _displayDelegate;
 
 - (void)destroyRender
 {

--- a/ijkmedia/ijksdl/metal/FSMetalView.m
+++ b/ijkmedia/ijksdl/metal/FSMetalView.m
@@ -167,6 +167,14 @@ NS_CLASS_AVAILABLE(10_13, 11_0)
 
 #pragma mark - FSVideoRenderingProtocol
 
+- (void)setDisplayDelegate:(id<FSVideoRenderingDelegate>)displayDelegate {
+    self.renderedView.displayDelegate = displayDelegate;
+}
+
+- (id<FSVideoRenderingDelegate>)displayDelegate {
+    return self.renderedView.displayDelegate;
+}
+
 - (void)setScalingMode:(FSScalingMode)scalingMode {
     if (self.renderedView.scalingMode != scalingMode) {
         [self makeNeedsLayout];
@@ -300,14 +308,6 @@ NS_CLASS_AVAILABLE(10_13, 11_0)
     [self.renderedView registerRefreshCurrentPicObserver:block];
 }
 
-- (void)setDisplayDelegate:(id<FSVideoRenderingDelegate>)displayDelegate {
-    self.renderedView.displayDelegate = displayDelegate;
-}
-
-- (id<FSVideoRenderingDelegate>)displayDelegate {
-    return self.renderedView.displayDelegate;
-}
-
 #if TARGET_OS_OSX
 - (NSView *)hitTest:(NSPoint)point
 {
@@ -362,6 +362,7 @@ NS_CLASS_AVAILABLE(10_13, 11_0)
 
 @implementation FSMetalRenderedView
 
+@synthesize displayDelegate = _displayDelegate;
 @synthesize scalingMode = _scalingMode;
 // rotate preference
 @synthesize rotatePreference = _rotatePreference;
@@ -375,8 +376,6 @@ NS_CLASS_AVAILABLE(10_13, 11_0)
 @synthesize scaleFactor = _scaleFactor;
 #endif
 @synthesize showHdrAnimation = _showHdrAnimation;
-
-@synthesize displayDelegate = _displayDelegate;
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {

--- a/ijkmedia/wrapper/apple/FSVideoRenderingProtocol.h
+++ b/ijkmedia/wrapper/apple/FSVideoRenderingProtocol.h
@@ -134,6 +134,8 @@ typedef enum : NSUInteger {
 
 @protocol FSVideoRenderingProtocol <NSObject>
 
+@property(nullable, nonatomic, weak) id <FSVideoRenderingDelegate> displayDelegate;
+
 @property(nonatomic) FSScalingMode scalingMode;
 #if TARGET_OS_IOS
 @property(nonatomic) CGFloat scaleFactor;
@@ -169,8 +171,6 @@ typedef enum : NSUInteger {
 @optional;
 - (void)setBackgroundColor:(uint8_t)r g:(uint8_t)g b:(uint8_t)b;
 - (void)registerRefreshCurrentPicObserver:(nullable dispatch_block_t)block;
-
-@property(nonatomic, weak) id <FSVideoRenderingDelegate> displayDelegate;
 
 @end
 


### PR DESCRIPTION
FSVideoRenderingProtocol，displayDelegate属性需要设置@required，在Swift中，会认为@optional可能不生成setter方法，导致无法设置displayDelegate，@required标记后OC使用也比较安全。